### PR TITLE
CLI option to specify GPU device ID

### DIFF
--- a/tuneIzh9p/MCNeuronSim.cpp
+++ b/tuneIzh9p/MCNeuronSim.cpp
@@ -109,11 +109,11 @@
 
 }
 
-	void MCNeuronSim::initNetwork(){
+	void MCNeuronSim::initNetwork(const int deviceID){
 			/**************
 		 * [I] construct a CARLsim network on the heap.
 		 ***************/
-			network = new CARLsim("MCNeuronSim_core", GPU_MODE, SILENT);
+	  network = new CARLsim("MCNeuronSim_core", GPU_MODE, SILENT, deviceID);
 	}
 
 	void MCNeuronSim::setupGroups(){

--- a/tuneIzh9p/core/MCNeuronSim.h
+++ b/tuneIzh9p/core/MCNeuronSim.h
@@ -51,7 +51,7 @@ class MCNeuronSim{
 
 		~MCNeuronSim();
 
-		void initNetwork();
+		void initNetwork(const int deviceID);
 		void setupGroups();
 		void setupAllNeuronParms();
 		void setupSingleNeuronParms(int grpRowId, int neurId, bool coupledComp);

--- a/tuneIzh9p/main_tuneIzh9p_4c2_wrapper.cpp
+++ b/tuneIzh9p/main_tuneIzh9p_4c2_wrapper.cpp
@@ -11,6 +11,7 @@
 #include <ctime>
 
 #include "core/MCNeuronSim.h"
+#include "parsingHelpers.h"
 
 using namespace CARLsim_PTI;
 
@@ -22,8 +23,11 @@ int MCNeuronSim::time_step =100;
 
 namespace CARLsim_PTI {
 class TuneIzh9p4c2Wrapper : public Experiment {
+private:
+  const unsigned int _deviceID;
 public:
-	TuneIzh9p4c2Wrapper() {}
+
+  TuneIzh9p4c2Wrapper(const unsigned int deviceID) : _deviceID(deviceID) {}
 
 	void run(const ParameterInstances &parameters, std::ostream &outputStream) const {
 
@@ -49,7 +53,7 @@ public:
 
 			MCNeuronSim* mc = new MCNeuronSim(compCnt, _connLayout, scenCount, popSize_neuronCount, _parameters);
 
-			mc->initNetwork();
+			mc->initNetwork(_deviceID);
 			mc->setupGroups();
 			mc->setupAllNeuronParms();
 			mc->setupIandRunNetwork();
@@ -74,7 +78,8 @@ int main(int argc, char* argv[]) {
 					fclose(fp);
 					delete fp;
 */
-		const TuneIzh9p4c2Wrapper tune4c2;
+  const int deviceID = getIntegerArgument("-device", argc, argv, 0);
+  const TuneIzh9p4c2Wrapper tune4c2(deviceID);
 		const PTI pti(argc, argv, std::cout, std::cin);
 		pti.runExperiment(tune4c2);
 

--- a/tuneIzh9p/parsingHelpers.h
+++ b/tuneIzh9p/parsingHelpers.h
@@ -1,0 +1,37 @@
+#ifndef PARSINGHELPERS_H
+#define PARSINGHELPERS_H
+
+
+static const char* getStringArgument(const char* const option, const int argc, const char* const argv[], const char * const def) {
+  assert(option != NULL);
+  assert(argc >= 0);
+  assert(argv != NULL);
+  for (int i = 0; i < argc - 1; i++) {
+    if (0 == strcmp(option, argv[i]))
+      return argv[i+1];
+  }
+  return def;
+}
+
+static int getIntegerArgument(const char* const option, const int argc, const char* const argv[], const int def) {
+  assert(option != NULL);
+  assert(argc >= 0);
+  assert(argv != NULL);
+  for (int i = 0; i < argc - 1; i++) {
+    if (0 == strcmp(option, argv[i]))
+      return atoi(argv[i+1]);
+  }
+  return def;
+}
+
+static bool getFlag(const char * const flag, const int argc, const char * const argv[]) {
+  assert(flag != NULL);
+  assert(argc >= 0);
+  assert(argv != NULL);
+  for (int i = 0; i < argc; i++) {
+    if (0 == strcmp(flag, argv[i]))
+      return true;
+  }
+  return false;
+}
+#endif /* PARSINGHELPERS_H */


### PR DESCRIPTION
Add a CLI argument to the 4c2 wrapper and an associated parameter to MCNeuronSim::initNetwork() to allow specifying the device ID of the GPU we want to execute on.  This is so I can run experiments on other GPUs while you're using the default one!
